### PR TITLE
Add bookmark shortcut

### DIFF
--- a/fftools/cmdutils.h
+++ b/fftools/cmdutils.h
@@ -243,6 +243,9 @@ typedef struct OptionDef {
 /* ffmpeg-only - OPT_PERFILE may apply to standalone decoders */
 #define OPT_DECODER     (1 << 15)
 
+/* This option is for use with FLNS videoJudging system */
+#define OPT_VJ          (1 << 16)
+
      union {
         void *dst_ptr;
         int (*func_arg)(void *, const char *, const char *);

--- a/fftools/ffplay.c
+++ b/fftools/ffplay.c
@@ -3396,6 +3396,7 @@ static void event_loop(VideoState* cur_stream) {
                                 av_log(NULL, AV_LOG_INFO, "\nBookmark created at %f\n", get_master_clock(cur_stream));
 			    else
 				av_log(NULL, AV_LOG_ERROR, "\nBookmark not created with command '%s'\n",command);
+			    do_exit(cur_stream);
                         }
                         break;
                     case SDLK_f:

--- a/fftools/ffplay.c
+++ b/fftools/ffplay.c
@@ -355,6 +355,8 @@ static int filter_nbthreads = 0;
 static int enable_vulkan = 0;
 static char* vulkan_params = NULL;
 static const char* hwaccel = NULL;
+static int recordId;
+static char* videoCentralUrl;
 
 /* current context */
 static int is_full_screen;
@@ -3385,6 +3387,14 @@ static void event_loop(VideoState* cur_stream) {
                 if (!cur_stream->width)
                     continue;
                 switch (event.key.keysym.sym) {
+                    case SDLK_b:
+                        if (videoCentralUrl && recordId) {
+                            char* command = av_asprintf("curl -x post %s/api/bookmark/recording/%d/%f?lane=999 >& /dev/null", videoCentralUrl, recordId,
+                                                     get_master_clock(cur_stream));
+                            if (!system(command))
+                                av_log(NULL, AV_LOG_INFO, "\nBookmark created at %f\n", get_master_clock(cur_stream));
+                        }
+                        break;
                     case SDLK_f:
                         toggle_full_screen(cur_stream);
                         cur_stream->force_refresh = 1;
@@ -3454,7 +3464,7 @@ static void event_loop(VideoState* cur_stream) {
                         goto do_seek;
                     case SDLK_RIGHT:
                         if (SDL_GetModState() & KMOD_CTRL) {
-                            incr = slow_seek_interval ? slow_seek_interval : 1.0;;
+                            incr = slow_seek_interval ? slow_seek_interval : 1.0;
                             goto do_seek;
                         }
                         incr = seek_interval ? seek_interval : 10.0;
@@ -3771,6 +3781,8 @@ static const OptionDef options[] = {
         "vulkan configuration using a list of key=value pairs separated by ':'"
     },
     {"hwaccel", OPT_TYPE_STRING, OPT_EXPERT, {&hwaccel}, "use HW accelerated decoding"},
+    {"recordId", OPT_TYPE_INT, OPT_VJ, {&recordId}, "id of the record to play", "xxx integer"},
+    {"vc", OPT_TYPE_STRING, OPT_VJ, {&videoCentralUrl}, "url of videoCentral", "http url"},
     {NULL,},
 };
 

--- a/fftools/ffplay.c
+++ b/fftools/ffplay.c
@@ -3389,10 +3389,13 @@ static void event_loop(VideoState* cur_stream) {
                 switch (event.key.keysym.sym) {
                     case SDLK_b:
                         if (videoCentralUrl && recordId) {
-                            char* command = av_asprintf("curl -x post %s/api/bookmark/recording/%d/%f?lane=999 >& /dev/null", videoCentralUrl, recordId,
-                                                     get_master_clock(cur_stream));
+                            char* command = av_asprintf("curl -D ffplay.%d.head -o ffplayi.%d.out -X POST %s/api/bookmark/recording/%d/%.0f?lane=99 >& ffplayi.%d.log", 
+				recordId, recordId, videoCentralUrl, recordId,
+                                get_master_clock(cur_stream), recordId);
                             if (!system(command))
                                 av_log(NULL, AV_LOG_INFO, "\nBookmark created at %f\n", get_master_clock(cur_stream));
+			    else
+				av_log(NULL, AV_LOG_ERROR, "\nBookmark not created with command '%s'\n",command);
                         }
                         break;
                     case SDLK_f:


### PR DESCRIPTION
This pull request introduces new features related to the FLNS videoJudging system and includes some minor cleanups. The key changes include adding a new option for videoJudging, introducing new variables for recording and video central URL, and implementing a bookmarking feature.

New features for videoJudging:

* [`fftools/cmdutils.h`](diffhunk://#diff-302fb18adcaf78dbedadef4fc32ae05575a007b90293e86fe4b31d385f009e35R246-R248): Added a new option `OPT_VJ` for use with the FLNS videoJudging system.
* [`fftools/ffplay.c`](diffhunk://#diff-d2b463b62a89d7db964eecf0de1a7ee9916378d403c7e6b03cbe1c52f45a1eceR358-R359): Introduced new variables `recordId` and `videoCentralUrl` to support videoJudging features.
* [`fftools/ffplay.c`](diffhunk://#diff-d2b463b62a89d7db964eecf0de1a7ee9916378d403c7e6b03cbe1c52f45a1eceR3390-R3397): Implemented a bookmarking feature triggered by the `SDLK_b` key, which sends a POST request to the videoCentral URL with the current recording ID and timestamp.
* [`fftools/ffplay.c`](diffhunk://#diff-d2b463b62a89d7db964eecf0de1a7ee9916378d403c7e6b03cbe1c52f45a1eceR3784-R3785): Added new command-line options `recordId` and `vc` to set the recording ID and videoCentral URL, respectively.

Minor cleanups:

* [`fftools/ffplay.c`](diffhunk://#diff-d2b463b62a89d7db964eecf0de1a7ee9916378d403c7e6b03cbe1c52f45a1eceL3457-R3467): Removed an extra semicolon in the `event_loop` function.